### PR TITLE
Generate error on unsupported platforms

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -4,6 +4,8 @@ mod linux;
 mod macos;
 #[cfg(windows)]
 mod windows;
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+mod unsupported;
 
 #[cfg(target_os = "linux")]
 pub use self::linux::swap;
@@ -11,3 +13,5 @@ pub use self::linux::swap;
 pub use self::macos::swap;
 #[cfg(windows)]
 pub use self::windows::swap;
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+pub use self::unsupported::swap;

--- a/src/platform/unsupported.rs
+++ b/src/platform/unsupported.rs
@@ -1,0 +1,6 @@
+use std::io;
+use std::path::Path;
+
+pub fn swap<A, B>(_a: A, _b: B) -> io::Result<()> where A: AsRef<Path>, B: AsRef<Path> {
+	Err(io::Error::new(io::ErrorKind::Other, "PathSwap not supported by the current platform"))
+}


### PR DESCRIPTION
tested by:

```bash
$ cargo build --target=armv7-linux-androideabi --verbose
    Updating registry `https://github.com/rust-lang/crates.io-index`
     Compiling libc v0.2.42                                                       
     Running `rustc --crate-name libc /root/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.42/src/lib.rs --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="use_std"' -C metadata=46292b5101ae535e -C extra-filename=-46292b5101ae535e --out-dir /usr/code/fs-swap/target/armv7-linux-androideabi/debug/deps --target armv7-linux-androideabi -C ar=arm-linux-androideabi-ar -C linker=arm-linux-androideabi-clang -L dependency=/usr/code/fs-swap/target/armv7-linux-androideabi/debug/deps -L dependency=/usr/code/fs-swap/target/debug/deps --cap-lints allow -C 'link-arg=-lc++_static' -C 'link-arg=-lc++abi' -C link-arg=-landroid_support`
   Compiling fs-swap v0.2.1 (file:///usr/code/fs-swap)
     Running `rustc --crate-name fs_swap src/lib.rs --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=d3543d39213713ed -C extra-filename=-d3543d39213713ed --out-dir /usr/code/fs-swap/target/armv7-linux-androideabi/debug/deps --target armv7-linux-androideabi -C ar=arm-linux-androideabi-ar -C linker=arm-linux-androideabi-clang -C incremental=/usr/code/fs-swap/target/armv7-linux-androideabi/debug/incremental -L dependency=/usr/code/fs-swap/target/armv7-linux-androideabi/debug/deps -L dependency=/usr/code/fs-swap/target/debug/deps --extern libc=/usr/code/fs-swap/target/armv7-linux-androideabi/debug/deps/liblibc-46292b5101ae535e.rlib -C 'link-arg=-lc++_static' -C 'link-arg=-lc++abi' -C link-arg=-landroid_support`
    Finished dev [unoptimized + debuginfo] target(s) in 0.81 secs
```

OT:
I don´t it is a good idea to use 
```toml
[target.'cfg(unix)'.dependencies]
libc = "0.2.4"
```
e.g, this will be compiled for android and all other `backlisted` unix-based OS'