### PR TITLE
Return errors when `swap_nonatomic` fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,21 +40,23 @@ pub fn swap_nonatomic<A, B>(a: A, b: B) -> io::Result<()> where A: AsRef<Path>, 
 
 	match fs::rename(b, a) {
 		Ok(_) => (),
-		Err(_) => {
+		Err(e) => {
 			// let's try to recover the previous state
 			// if it fails, there is nothing we can do
-			return fs::rename(&tmp, a);
+			fs::rename(&tmp, a)?;
+			return Err(e)
 		},
 	}
 
 	// rename tmp to b
 	match fs::rename(&tmp, b) {
 		Ok(_) => Ok(()),
-		Err(_) => {
+		Err(e) => {
 			// let's try to recover to previous state
 			// if it fails, there is nothing we can do
 			fs::rename(a, b)?;
-			fs::rename(&tmp, a)
+			fs::rename(&tmp, a)?;
+			Err(e)
 		},
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,23 +40,23 @@ pub fn swap_nonatomic<A, B>(a: A, b: B) -> io::Result<()> where A: AsRef<Path>, 
 
 	match fs::rename(b, a) {
 		Ok(_) => (),
-		Err(e) => {
+		error => {
 			// let's try to recover the previous state
 			// if it fails, there is nothing we can do
 			fs::rename(&tmp, a)?;
-			return Err(e)
+			return error
 		},
 	}
 
 	// rename tmp to b
 	match fs::rename(&tmp, b) {
 		Ok(_) => Ok(()),
-		Err(e) => {
+		error => {
 			// let's try to recover to previous state
 			// if it fails, there is nothing we can do
 			fs::rename(a, b)?;
 			fs::rename(&tmp, a)?;
-			Err(e)
+			error
 		},
 	}
 }


### PR DESCRIPTION
Don't silently fail when non-atomic swap fails