### PR TITLE
Change renameat2 type to c_uint

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -6,7 +6,7 @@ use std::{io, ffi};
 
 unsafe fn renameat2(
 	olddirfd: libc::c_int, oldpath: *const libc::c_char, 
-	newdirfd: libc::c_int, newpath: *const libc::c_char, flags: libc::c_int
+	newdirfd: libc::c_int, newpath: *const libc::c_char, flags: libc::c_uint
 ) -> libc::c_int {
 	libc::syscall(libc::SYS_renameat2, olddirfd, oldpath, newdirfd, newpath, flags) as libc::c_int
 }


### PR DESCRIPTION
The type of `RENAME_EXCHANGE` has changed to `c_uint` see RENAME_EXCHANGE in `libc`: https://github.com/rust-lang/libc/commit/b90fda7decf7cf4ae7401966ed59da12d4b4ac4d.

Note that we can't use `renameat2` directly yet since it is not yet widely supported in glibc.